### PR TITLE
add consola to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "unbuild": "^2.0.0",
     "vitest": "^2.1.3"
   },
+  "peerDependencies": {
+    "consola": "^3"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/shoma-mano/maests.git"


### PR DESCRIPTION
Great project, I really like the idea and API !
I encountered a small issue because the package `consola` was not already in the project.
Adding it to peerDependencies should fix this issue.

```shell
> npx maests ./maestro/flows/my-first-flow.ts
file:///Users/lmueller/rio/pocket-driver-app/node_modules/maests/dist/index.mjs:6
import { consola } from "consola";
         ^^^^^^^
SyntaxError: Named export 'consola' not found. The requested module 'consola' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'consola';
const { consola } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:134:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:217:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:123:5)

Node.js v20.14.0```